### PR TITLE
Bug fix: request bodies larger than server readsize no longer cause servert to hang

### DIFF
--- a/lib/tanzer/session.tcl
+++ b/lib/tanzer/session.tcl
@@ -249,7 +249,7 @@ namespace eval ::tanzer::session {
 #
 ::oo::define ::tanzer::session method handle {event} {
     my variable sock server request keepalive \
-        buffer config handler watchdog
+        buffer config handler watchdog remaining
 
     set requestBodyFinished 0
 


### PR DESCRIPTION
Because remaining wasn properly set as a field on the session, it was reset each time [handle] was called. Fixes #2.