### PR TITLE
Two features: more robust [session store] variables and expose body read status

### DIFF
--- a/lib/tanzer/session.tcl
+++ b/lib/tanzer/session.tcl
@@ -741,7 +741,11 @@ namespace eval ::tanzer::session {
     switch -- [llength $args] 0 {
         return $store
     } 1 {
-        return [dict get $store [lindex $args 0]]
+        set key [lindex $args 0]
+        if {[dict exists $store $key]} {
+            return [dict get $store $key]
+        }
+        return {}
     } 2 {
         dict set store [lindex $args 0] [lindex $args 1]
         return


### PR DESCRIPTION
1d2b509 allows one to call `[$session store data]` without fear of getting an error if that key has not yet been set.

ee6852d gives the route handler a way to know whether the entire request body has been read yet. If there is another way to accomplish this, please let me know...I couldn't find one. For use example: https://github.com/raztus/file-tally/blob/master/main.tcl#L38 

Let me know if you prefer this as two separate pull requests.