### PR TITLE
More robust session store.

### DIFF
--- a/lib/tanzer/session.tcl
+++ b/lib/tanzer/session.tcl
@@ -735,7 +735,11 @@ namespace eval ::tanzer::session {
     switch -- [llength $args] 0 {
         return $store
     } 1 {
-        return [dict get $store [lindex $args 0]]
+        set key [lindex $args 0]
+        if {[dict exists $store $key]} {
+            return [dict get $store $key]
+        }
+        return {}
     } 2 {
         dict set store [lindex $args 0] [lindex $args 1]
         return


### PR DESCRIPTION
Make it safe to access a stored session variable without the caller knowing it's a dict: allows one to call `[$session store data]` without fear of getting an error if that key has not yet been set.